### PR TITLE
Extend dataset processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ python3 perceptron.py
 ## Example: Word Dataset Processor
 
 The processor script demonstrates the additional utilities described above. It
-builds a vocabulary from an in-memory dataset and prints TF‑IDF vectors.
+can load individual files or entire directories of `.txt`, `.csv`, `.json`, `.xml`,
+`.html`, and `.md` data, build a vocabulary, and print TF‑IDF vectors.
 
 ### Running
 
@@ -79,7 +80,7 @@ python3 word_dataset_processor.py | head -n 10
 ## Example: Layered Models
 
 The `layered_models.py` script builds extremely deep networks to demonstrate
-handling of text and numeric data. It runs a 20-layer model on short text
+handling of text and numeric data. It now runs a 30-layer model on short text
 samples and a 30-layer model on simple numeric input.
 
 ### Running
@@ -92,10 +93,30 @@ python3 layered_models.py | head -n 10
 
 The `ai_model.py` script aggregates the algorithms and chooses one based on a task label.
 Supported labels include `classification`, `regression`, `clustering`, `nlp`,
-`reinforcement`, `evolution`, `text20`, and `data30`.
+`reinforcement`, `evolution`, `text30`, `data30`, `train_csv`, and
+`train_folder`. The `nlp` task can optionally accept a file or directory
+path to process.
 
 ### Running
 
 ```bash
 python3 ai_model.py classification
+```
+
+To process text from a directory and compute TF‑IDF vectors:
+
+```bash
+python3 ai_model.py nlp my_texts/
+```
+
+To train logistic regression on a CSV file with the label in the last column:
+
+```bash
+python3 ai_model.py train_csv data.csv
+```
+
+To run the extremely deep text model:
+
+```bash
+python3 ai_model.py text30
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
 # docker-AI-
+
+This repository demonstrates how to build AI models from scratch using only Python's standard library.
+
+## Example: Logistic Regression
+
+The `logistic_regression.py` script implements logistic regression without external machine learning packages. It trains on a small OR gate dataset and prints predictions after training.
+
+### Running
+
+```bash
+python3 logistic_regression.py
+```
+
+You should see output showing the probability and predicted class for each input sample.
+
+## Example: Simple Neural Network
+
+The `simple_nn.py` script implements a small neural network with one hidden layer. It learns the XOR gate truth table and reports the training accuracy.
+
+### Running
+
+```bash
+python3 simple_nn.py
+```
+
+
+## Example: Deep Neural Network
+
+The `complex_nn.py` script demonstrates a deeper network with two hidden layers trained on a synthetic concentric circles dataset. This shows how a neural network can learn a non-linear decision boundary.
+
+### Running
+
+```bash
+python3 complex_nn.py
+```
+
+The script prints the training accuracy and probabilities for a few samples.
+
+## Additional Examples
+
+The following scripts illustrate more advanced algorithms, all implemented from scratch:
+
+- `perceptron.py` – trains a simple perceptron on the AND gate.
+- `linear_regression.py` – fits a line to synthetic data using gradient descent.
+- `kmeans.py` – demonstrates k-means clustering on a small dataset.
+- `naive_bayes.py` – naive Bayes text classifier for spam vs ham.
+- `knn.py` – k-nearest neighbors classifier for the OR gate.
+- `decision_tree.py` – builds a tiny decision tree for the XOR problem.
+- `pca.py` – runs principal component analysis to reduce dimensionality.
+- `q_learning.py` – tabular Q-learning in a simple grid world.
+- `genetic_algorithm.py` – evolves a string to match a target phrase.
+- `rnn.py` – recurrent neural network that predicts sequence parity.
+- `conv_net.py` – small 1-D convolutional network with max pooling.
+- `autoencoder.py` – trains an autoencoder to reconstruct binary vectors.
+- `word_dataset_processor.py` – flexible text processor with loaders for
+  `.txt`, `.csv`, `.json`, `.xml`, `.html`, and `.md` files. It includes
+  utilities like stopword removal, stemming, n-grams, and TF-IDF vectors.
+
+Each script can be executed individually, for example:
+
+```bash
+python3 perceptron.py
+```
+
+## Example: Word Dataset Processor
+
+The processor script demonstrates the additional utilities described above. It
+builds a vocabulary from an in-memory dataset and prints TF‑IDF vectors.
+
+### Running
+
+```bash
+python3 word_dataset_processor.py | head -n 10
+```
+
+## Example: Auto System
+
+The `ai_model.py` script aggregates the algorithms and chooses one based on a task label.
+Supported labels include `classification`, `regression`, `clustering`, `nlp`,
+`reinforcement`, and `evolution`.
+
+### Running
+
+```bash
+python3 ai_model.py classification
+```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The following scripts illustrate more advanced algorithms, all implemented from 
 - `word_dataset_processor.py` – flexible text processor with loaders for
   `.txt`, `.csv`, `.json`, `.xml`, `.html`, and `.md` files. It includes
   utilities like stopword removal, stemming, n-grams, and TF-IDF vectors.
+- `layered_models.py` – demonstrates very deep networks with 20 layers for
+  text samples and 30 layers for numeric data.
 
 Each script can be executed individually, for example:
 
@@ -74,11 +76,23 @@ builds a vocabulary from an in-memory dataset and prints TF‑IDF vectors.
 python3 word_dataset_processor.py | head -n 10
 ```
 
+## Example: Layered Models
+
+The `layered_models.py` script builds extremely deep networks to demonstrate
+handling of text and numeric data. It runs a 20-layer model on short text
+samples and a 30-layer model on simple numeric input.
+
+### Running
+
+```bash
+python3 layered_models.py | head -n 10
+```
+
 ## Example: Auto System
 
 The `ai_model.py` script aggregates the algorithms and chooses one based on a task label.
 Supported labels include `classification`, `regression`, `clustering`, `nlp`,
-`reinforcement`, and `evolution`.
+`reinforcement`, `evolution`, `text20`, and `data30`.
 
 ### Running
 

--- a/ai_model.py
+++ b/ai_model.py
@@ -21,8 +21,31 @@ from layered_models import run_text_model, run_data_model
 class AutoSystem:
     """Select and run algorithms based on a simple task label."""
 
-    def __init__(self):
-        pass
+    def __init__(self, path: str | None = None):
+        self.path = path
+
+    def _load_csv(self, path: str):
+        import csv
+        data = []
+        with open(path, newline="", encoding="utf-8") as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                if not row:
+                    continue
+                data.append([float(x) for x in row])
+        X = [r[:-1] for r in data]
+        y = [int(r[-1]) for r in data]
+        return X, y
+
+    def _load_csv_folder(self, folder: str):
+        import os
+        all_X, all_y = [], []
+        for name in os.listdir(folder):
+            if name.endswith('.csv'):
+                X, y = self._load_csv(os.path.join(folder, name))
+                all_X.extend(X)
+                all_y.extend(y)
+        return all_X, all_y
 
     def run(self, task: str):
         task = task.lower()
@@ -51,11 +74,14 @@ class AutoSystem:
                 cluster = km.predict(x)
                 print(f"Point {x} => Cluster {cluster}")
         elif task == "nlp":
-            texts = [
-                "The quick brown fox jumps over the lazy dog",
-                "Never jump over the lazy dog quickly",
-            ]
             tp = TextProcessor()
+            if self.path:
+                texts = tp.load_path(self.path)
+            else:
+                texts = [
+                    "The quick brown fox jumps over the lazy dog",
+                    "Never jump over the lazy dog quickly",
+                ]
             vectors = tp.fit_transform(texts)
             print("Vocabulary:", tp.vocab)
             for t, v in zip(texts, vectors):
@@ -76,13 +102,30 @@ class AutoSystem:
             ga = GA(pop_size=20)
             best = ga.evolve(generations=200)
             print("Evolved:", ''.join(best.genes))
-        elif task == "text20":
+        elif task == "text30":
             run_text_model()
         elif task == "data30":
             run_data_model()
+        elif task == "train_csv" and self.path:
+            X, y = self._load_csv(self.path)
+            model = LogisticRegression(n_features=len(X[0]))
+            model.train(X, y, epochs=3000)
+            for x, label in zip(X, y):
+                pred = model.predict(x)
+                print(f"{x} label={label} => {pred}")
+        elif task == "train_folder" and self.path:
+            X, y = self._load_csv_folder(self.path)
+            model = LogisticRegression(n_features=len(X[0]))
+            model.train(X, y, epochs=3000)
+            correct = sum(model.predict(x) == y_i for x, y_i in zip(X, y))
+            acc = correct / len(y) * 100
+            print(f"Folder training accuracy: {acc:.1f}%")
         else:
-            print("Unknown task. Available tasks: classification, regression, clustering, nlp, reinforcement, evolution, text20, data30")
+            print(
+                "Unknown task. Available tasks: classification, regression, clustering, nlp, reinforcement, evolution, text30, data30, train_csv, train_folder"
+            )
 
 if __name__ == "__main__":
     task = sys.argv[1] if len(sys.argv) > 1 else "classification"
-    AutoSystem().run(task)
+    path = sys.argv[2] if len(sys.argv) > 2 else None
+    AutoSystem(path).run(task)

--- a/ai_model.py
+++ b/ai_model.py
@@ -1,0 +1,83 @@
+import sys
+
+from logistic_regression import LogisticRegression
+from linear_regression import LinearRegression
+from kmeans import KMeans
+from naive_bayes import NaiveBayes
+from knn import KNearestNeighbors
+from decision_tree import DecisionTree
+from perceptron import Perceptron
+from pca import PCA
+from q_learning import GridWorld, QLearningAgent
+from genetic_algorithm import GA
+from rnn import SimpleRNN
+from conv_net import ConvNet1D
+from autoencoder import Autoencoder
+from simple_nn import SimpleNeuralNetwork
+from complex_nn import DeepNeuralNetwork
+from word_dataset_processor import TextProcessor
+
+class AutoSystem:
+    """Select and run algorithms based on a simple task label."""
+
+    def __init__(self):
+        pass
+
+    def run(self, task: str):
+        task = task.lower()
+        if task == "classification":
+            X = [[0, 0], [0, 1], [1, 0], [1, 1]]
+            y = [0, 1, 1, 1]
+            model = LogisticRegression(n_features=2)
+            model.train(X, y, epochs=3000)
+            for x in X:
+                prob = model.predict_proba(x)
+                pred = model.predict(x)
+                print(f"LogReg {x} => {pred} ({prob:.2f})")
+        elif task == "regression":
+            X = list(range(10))
+            y = [2 * x + 1 for x in X]
+            model = LinearRegression()
+            model.train(X, y, epochs=2000, lr=0.01)
+            for x in X:
+                pred = model.predict(x)
+                print(f"x={x} => {pred:.2f}")
+        elif task == "clustering":
+            X = [[1, 2], [1, 3], [8, 8], [9, 8]]
+            km = KMeans(k=2)
+            km.fit(X)
+            for x in X:
+                cluster = km.predict(x)
+                print(f"Point {x} => Cluster {cluster}")
+        elif task == "nlp":
+            texts = [
+                "The quick brown fox jumps over the lazy dog",
+                "Never jump over the lazy dog quickly",
+            ]
+            tp = TextProcessor()
+            vectors = tp.fit_transform(texts)
+            print("Vocabulary:", tp.vocab)
+            for t, v in zip(texts, vectors):
+                print(t)
+                print([f"{x:.2f}" for x in v])
+        elif task == "reinforcement":
+            env = GridWorld(n_states=5)
+            agent = QLearningAgent(n_states=5)
+            agent.learn(env, episodes=200)
+            state = 0
+            steps = 0
+            while state != env.end and steps < 10:
+                action = agent.choose_action(state, eps=0)
+                state, _ = env.step(state, action)
+                print(f"State: {state}")
+                steps += 1
+        elif task == "evolution":
+            ga = GA(pop_size=20)
+            best = ga.evolve(generations=200)
+            print("Evolved:", ''.join(best.genes))
+        else:
+            print("Unknown task. Available tasks: classification, regression, clustering, nlp, reinforcement, evolution")
+
+if __name__ == "__main__":
+    task = sys.argv[1] if len(sys.argv) > 1 else "classification"
+    AutoSystem().run(task)

--- a/ai_model.py
+++ b/ai_model.py
@@ -16,6 +16,7 @@ from autoencoder import Autoencoder
 from simple_nn import SimpleNeuralNetwork
 from complex_nn import DeepNeuralNetwork
 from word_dataset_processor import TextProcessor
+from layered_models import run_text_model, run_data_model
 
 class AutoSystem:
     """Select and run algorithms based on a simple task label."""
@@ -75,8 +76,12 @@ class AutoSystem:
             ga = GA(pop_size=20)
             best = ga.evolve(generations=200)
             print("Evolved:", ''.join(best.genes))
+        elif task == "text20":
+            run_text_model()
+        elif task == "data30":
+            run_data_model()
         else:
-            print("Unknown task. Available tasks: classification, regression, clustering, nlp, reinforcement, evolution")
+            print("Unknown task. Available tasks: classification, regression, clustering, nlp, reinforcement, evolution, text20, data30")
 
 if __name__ == "__main__":
     task = sys.argv[1] if len(sys.argv) > 1 else "classification"

--- a/autoencoder.py
+++ b/autoencoder.py
@@ -1,0 +1,61 @@
+import random
+import math
+
+class Autoencoder:
+    def __init__(self, n_inputs, n_hidden):
+        self.w1 = [[random.uniform(-0.5,0.5) for _ in range(n_inputs)] for _ in range(n_hidden)]
+        self.b1 = [0.0]*n_hidden
+        self.w2 = [[random.uniform(-0.5,0.5) for _ in range(n_hidden)] for _ in range(n_inputs)]
+        self.b2 = [0.0]*n_inputs
+
+    def _sigmoid(self, z):
+        return 1/(1+math.exp(-z))
+
+    def _sigmoid_deriv(self, a):
+        return a*(1-a)
+
+    def encode(self, x):
+        hidden = []
+        for w,b in zip(self.w1,self.b1):
+            z = sum(w_i*x_i for w_i,x_i in zip(w,x)) + b
+            hidden.append(self._sigmoid(z))
+        return hidden
+
+    def decode(self, h):
+        out = []
+        for w,b in zip(self.w2,self.b2):
+            z = sum(w_i*h_i for w_i,h_i in zip(w,h)) + b
+            out.append(self._sigmoid(z))
+        return out
+
+    def train(self, X, epochs=1000, lr=0.1):
+        for _ in range(epochs):
+            for x in X:
+                h = self.encode(x)
+                out = self.decode(h)
+                # output error
+                delta_out = [o - x_i for o,x_i in zip(out,x)]
+                # hidden error
+                delta_h = []
+                for j in range(len(self.w1)):
+                    err = sum(self.w2[i][j]*delta_out[i] for i in range(len(x)))
+                    delta_h.append(err*self._sigmoid_deriv(h[j]))
+                # update output weights
+                for i in range(len(self.w2)):
+                    for j in range(len(self.w2[i])):
+                        self.w2[i][j] -= lr * delta_out[i] * h[j]
+                    self.b2[i] -= lr * delta_out[i]
+                # update input weights
+                for j in range(len(self.w1)):
+                    for i in range(len(self.w1[j])):
+                        self.w1[j][i] -= lr * delta_h[j]*x[i]
+                    self.b1[j] -= lr * delta_h[j]
+
+if __name__ == "__main__":
+    X = [[0,0],[0,1],[1,0],[1,1]]
+    ae = Autoencoder(n_inputs=2, n_hidden=2)
+    ae.train(X, epochs=500)
+    for x in X:
+        h = ae.encode(x)
+        out = ae.decode(h)
+        print(f"Input: {x} => Reconstructed: {[round(o,2) for o in out]}")

--- a/complex_nn.py
+++ b/complex_nn.py
@@ -1,0 +1,111 @@
+import random
+import math
+
+class DeepNeuralNetwork:
+    def __init__(self, layer_sizes):
+        self.layer_sizes = layer_sizes
+        self.weights = []
+        self.biases = []
+        for i in range(len(layer_sizes) - 1):
+            in_size = layer_sizes[i]
+            out_size = layer_sizes[i+1]
+            w = [[random.uniform(-0.5, 0.5) for _ in range(in_size)] for _ in range(out_size)]
+            b = [random.uniform(-0.5, 0.5) for _ in range(out_size)]
+            self.weights.append(w)
+            self.biases.append(b)
+
+    def _relu(self, z):
+        return max(0.0, z)
+
+    def _relu_deriv(self, a):
+        return 1.0 if a > 0 else 0.0
+
+    def _sigmoid(self, z):
+        return 1 / (1 + math.exp(-z))
+
+    def _forward(self, x):
+        activations = [x]
+        a = x
+        for idx, (w, b) in enumerate(zip(self.weights, self.biases)):
+            z = []
+            for weights, bias in zip(w, b):
+                z_val = sum(w_i * a_i for w_i, a_i in zip(weights, a)) + bias
+                z.append(z_val)
+            if idx == len(self.weights) - 1:
+                a = [self._sigmoid(v) for v in z]
+            else:
+                a = [self._relu(v) for v in z]
+            activations.append(a)
+        return activations
+
+    def predict_proba(self, x):
+        activations = self._forward(x)
+        return activations[-1][0]
+
+    def predict(self, x):
+        return 1 if self.predict_proba(x) >= 0.5 else 0
+
+    def _backward(self, activations, y):
+        grads_w = [None] * len(self.weights)
+        grads_b = [None] * len(self.biases)
+        # output layer delta (assuming binary classification)
+        delta = [activations[-1][0] - y]
+        grads_w[-1] = [[delta[0] * a for a in activations[-2]]]
+        grads_b[-1] = delta[:]
+        # backpropagate through hidden layers
+        for l in range(len(self.weights) - 2, -1, -1):
+            next_w = self.weights[l+1]
+            new_delta = []
+            for j in range(len(self.weights[l])):
+                error = sum(next_w[k][j] * delta[k] for k in range(len(delta)))
+                new_delta.append(error * self._relu_deriv(activations[l+1][j]))
+            delta = new_delta
+            grads_w[l] = [[delta[i] * activations[l][j] for j in range(len(activations[l]))] for i in range(len(delta))]
+            grads_b[l] = delta[:]
+        return grads_w, grads_b
+
+    def train(self, X, y, epochs=1000, lr=0.1):
+        for _ in range(epochs):
+            for x_i, y_i in zip(X, y):
+                activations = self._forward(x_i)
+                grads_w, grads_b = self._backward(activations, y_i)
+                for l in range(len(self.weights)):
+                    for i in range(len(self.weights[l])):
+                        for j in range(len(self.weights[l][i])):
+                            self.weights[l][i][j] -= lr * grads_w[l][i][j]
+                        self.biases[l][i] -= lr * grads_b[l][i]
+
+    def evaluate(self, X, y):
+        correct = 0
+        for x_i, y_i in zip(X, y):
+            if self.predict(x_i) == y_i:
+                correct += 1
+        return correct / len(X)
+
+
+def make_circles(n_samples=200, noise=0.1):
+    X = []
+    y = []
+    for _ in range(n_samples // 2):
+        theta = random.uniform(0, 2 * math.pi)
+        r = 1 + random.uniform(-noise, noise)
+        X.append([r * math.cos(theta), r * math.sin(theta)])
+        y.append(0)
+    for _ in range(n_samples // 2):
+        theta = random.uniform(0, 2 * math.pi)
+        r = 2 + random.uniform(-noise, noise)
+        X.append([r * math.cos(theta), r * math.sin(theta)])
+        y.append(1)
+    return X, y
+
+if __name__ == "__main__":
+    X, y = make_circles(n_samples=200, noise=0.1)
+    nn = DeepNeuralNetwork([2, 4, 4, 1])
+    nn.train(X, y, epochs=1000, lr=0.05)
+    acc = nn.evaluate(X, y)
+    print(f"Training accuracy: {acc * 100:.2f}%")
+    for i in range(5):
+        prob = nn.predict_proba(X[i])
+        pred = nn.predict(X[i])
+        print(f"Sample {i}: Prob={prob:.3f}, Pred={pred}")
+

--- a/conv_net.py
+++ b/conv_net.py
@@ -1,0 +1,50 @@
+import random
+import math
+
+class ConvNet1D:
+    def __init__(self, filter_size):
+        self.filter = [random.uniform(-0.5,0.5) for _ in range(filter_size)]
+        self.bias = random.uniform(-0.5,0.5)
+        self.fc_w = random.uniform(-0.5,0.5)
+        self.fc_b = random.uniform(-0.5,0.5)
+
+    def _convolve(self, x):
+        out = []
+        for i in range(len(x)-len(self.filter)+1):
+            val = sum(f*x[i+j] for j,f in enumerate(self.filter)) + self.bias
+            out.append(max(0,val))  # ReLU
+        return max(out)  # global max pooling
+
+    def predict_proba(self, x):
+        feat = self._convolve(x)
+        z = feat * self.fc_w + self.fc_b
+        return 1/(1+math.exp(-z))
+
+    def predict(self, x):
+        return 1 if self.predict_proba(x) >= 0.5 else 0
+
+    def train(self, X, y, epochs=200, lr=0.01):
+        for _ in range(epochs):
+            for x_i, y_i in zip(X, y):
+                feat = self._convolve(x_i)
+                prob = self.predict_proba(x_i)
+                error = prob - y_i
+                # gradients
+                self.fc_w -= lr * error * feat
+                self.fc_b -= lr * error
+                # backprop through conv filter (approx via single max position)
+                idx = max(range(len(x_i)-len(self.filter)+1), key=lambda i: sum(self.filter[j]*x_i[i+j] for j in range(len(self.filter))))
+                for j in range(len(self.filter)):
+                    grad = error * self.fc_w * x_i[idx+j]
+                    self.filter[j] -= lr * grad
+                self.bias -= lr * error
+
+if __name__ == "__main__":
+    # sequences with high sum vs low sum
+    X = [[0,0,0,1],[1,1,1,1],[0,1,0,1],[1,0,1,0]]
+    y = [0,1,0,1]
+    net = ConvNet1D(filter_size=2)
+    net.train(X, y, epochs=200)
+    for seq in X:
+        pred = net.predict(seq)
+        print(f"Seq: {seq} => Predicted: {pred}")

--- a/decision_tree.py
+++ b/decision_tree.py
@@ -1,0 +1,72 @@
+import math
+
+class Node:
+    def __init__(self, feature=None, threshold=None, left=None, right=None, label=None):
+        self.feature = feature
+        self.threshold = threshold
+        self.left = left
+        self.right = right
+        self.label = label
+
+class DecisionTree:
+    def _entropy(self, labels):
+        total = len(labels)
+        counts = [labels.count(0), labels.count(1)]
+        ent = 0.0
+        for c in counts:
+            if c > 0:
+                p = c / total
+                ent -= p * math.log2(p)
+        return ent
+
+    def _best_split(self, X, y):
+        best_gain = 0
+        best_feat = None
+        for feat in range(len(X[0])):
+            left_y = [y[i] for i in range(len(X)) if X[i][feat] == 0]
+            right_y = [y[i] for i in range(len(X)) if X[i][feat] == 1]
+            if not left_y or not right_y:
+                continue
+            h_before = self._entropy(y)
+            h_after = (len(left_y)/len(y))*self._entropy(left_y) + (len(right_y)/len(y))*self._entropy(right_y)
+            gain = h_before - h_after
+            if gain > best_gain:
+                best_gain = gain
+                best_feat = feat
+        return best_feat
+
+    def _build(self, X, y):
+        if all(label == y[0] for label in y):
+            return Node(label=y[0])
+        feat = self._best_split(X, y)
+        if feat is None:
+            majority = 1 if y.count(1) >= y.count(0) else 0
+            return Node(label=majority)
+        left_X = [x for x in X if x[feat] == 0]
+        left_y = [y[i] for i in range(len(X)) if X[i][feat] == 0]
+        right_X = [x for x in X if x[feat] == 1]
+        right_y = [y[i] for i in range(len(X)) if X[i][feat] == 1]
+        left = self._build(left_X, left_y)
+        right = self._build(right_X, right_y)
+        return Node(feature=feat, threshold=1, left=left, right=right)
+
+    def fit(self, X, y):
+        self.root = self._build(X, y)
+
+    def _predict(self, node, x):
+        if node.label is not None:
+            return node.label
+        branch = node.left if x[node.feature] == 0 else node.right
+        return self._predict(branch, x)
+
+    def predict(self, x):
+        return self._predict(self.root, x)
+
+if __name__ == "__main__":
+    X = [[0,0],[0,1],[1,0],[1,1]]
+    y = [0,1,1,0]  # XOR
+    tree = DecisionTree()
+    tree.fit(X, y)
+    for x in X:
+        pred = tree.predict(x)
+        print(f"Input: {x} => Predicted: {pred}")

--- a/genetic_algorithm.py
+++ b/genetic_algorithm.py
@@ -1,0 +1,48 @@
+import random
+
+target = "hello"
+
+class Individual:
+    def __init__(self, genes=None):
+        if genes is None:
+            genes = [chr(random.randint(97,122)) for _ in target]
+        self.genes = genes
+        self.fitness = self.evaluate()
+
+    def evaluate(self):
+        return sum(g == t for g,t in zip(self.genes, target))
+
+    def mutate(self, rate=0.1):
+        for i in range(len(self.genes)):
+            if random.random() < rate:
+                self.genes[i] = chr(random.randint(97,122))
+        self.fitness = self.evaluate()
+
+    def crossover(self, other):
+        point = random.randint(1, len(self.genes)-1)
+        child_genes = self.genes[:point] + other.genes[point:]
+        return Individual(child_genes)
+
+class GA:
+    def __init__(self, pop_size=20):
+        self.population = [Individual() for _ in range(pop_size)]
+
+    def evolve(self, generations=100):
+        for _ in range(generations):
+            self.population.sort(key=lambda ind: ind.fitness, reverse=True)
+            if self.population[0].fitness == len(target):
+                break
+            next_gen = self.population[:2]
+            while len(next_gen) < len(self.population):
+                parent1 = random.choice(self.population[:10])
+                parent2 = random.choice(self.population[:10])
+                child = parent1.crossover(parent2)
+                child.mutate()
+                next_gen.append(child)
+            self.population = next_gen
+        return self.population[0]
+
+if __name__ == "__main__":
+    ga = GA(pop_size=20)
+    best = ga.evolve(generations=200)
+    print("Evolved:", ''.join(best.genes))

--- a/kmeans.py
+++ b/kmeans.py
@@ -1,0 +1,34 @@
+import random
+import math
+
+class KMeans:
+    def __init__(self, k):
+        self.k = k
+        self.centers = []
+
+    def _distance(self, a, b):
+        return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+    def fit(self, X, epochs=10):
+        self.centers = random.sample(X, self.k)
+        for _ in range(epochs):
+            clusters = [[] for _ in range(self.k)]
+            for x in X:
+                distances = [self._distance(x, c) for c in self.centers]
+                idx = distances.index(min(distances))
+                clusters[idx].append(x)
+            for i, cluster in enumerate(clusters):
+                if cluster:
+                    self.centers[i] = [sum(dim)/len(dim) for dim in zip(*cluster)]
+
+    def predict(self, x):
+        distances = [self._distance(x, c) for c in self.centers]
+        return distances.index(min(distances))
+
+if __name__ == "__main__":
+    X = [[1,2], [1,3], [8,8], [9,8]]
+    model = KMeans(k=2)
+    model.fit(X, epochs=5)
+    for x in X:
+        cluster = model.predict(x)
+        print(f"Point {x} => Cluster {cluster}")

--- a/knn.py
+++ b/knn.py
@@ -1,0 +1,30 @@
+import math
+
+class KNearestNeighbors:
+    def __init__(self, k=3):
+        self.k = k
+        self.X = []
+        self.y = []
+
+    def _distance(self, a, b):
+        return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+    def train(self, X, y):
+        self.X = X
+        self.y = y
+
+    def predict(self, x):
+        distances = [self._distance(x, xi) for xi in self.X]
+        pairs = sorted(zip(distances, self.y))[:self.k]
+        votes = sum(label for _, label in pairs)
+        return 1 if votes >= self.k / 2 else 0
+
+if __name__ == "__main__":
+    X = [[0,0],[0,1],[1,0],[1,1]]
+    y = [0,1,1,1]  # OR gate
+
+    knn = KNearestNeighbors(k=3)
+    knn.train(X, y)
+    for x in X:
+        pred = knn.predict(x)
+        print(f"Input: {x} => Predicted: {pred}")

--- a/layered_models.py
+++ b/layered_models.py
@@ -1,0 +1,44 @@
+import random
+from complex_nn import DeepNeuralNetwork
+from word_dataset_processor import TextProcessor
+
+
+def run_text_model():
+    """Train a 20-layer network on a tiny text dataset."""
+    texts = [
+        "Cats are wonderful pets",
+        "Dogs are loyal animals",
+        "Economics affects markets",
+        "Finance drives business",
+    ]
+    labels = [1, 1, 0, 0]
+    tp = TextProcessor()
+    vectors = tp.fit_transform(texts)
+    input_size = len(tp.vocab)
+    # input + 18 hidden + output = 20 layers total
+    layer_sizes = [input_size] + [8] * 18 + [1]
+    net = DeepNeuralNetwork(layer_sizes)
+    net.train(vectors, labels, epochs=200, lr=0.05)
+    for t, v in zip(texts, vectors):
+        prob = net.predict_proba(v)
+        pred = net.predict(v)
+        print(f"Text: {t} => {pred} ({prob:.2f})")
+
+
+def run_data_model():
+    """Train a 30-layer network on simple numeric data."""
+    X = [[x] for x in range(10)]
+    y = [1 if x > 5 else 0 for x in range(10)]
+    # input + 28 hidden + output = 30 layers total
+    layer_sizes = [1] + [4] * 28 + [1]
+    net = DeepNeuralNetwork(layer_sizes)
+    net.train(X, y, epochs=200, lr=0.05)
+    for x, label in zip(X, y):
+        prob = net.predict_proba(x)
+        pred = net.predict(x)
+        print(f"x={x[0]} label={label} => {pred} ({prob:.2f})")
+
+
+if __name__ == "__main__":
+    run_text_model()
+    run_data_model()

--- a/layered_models.py
+++ b/layered_models.py
@@ -4,7 +4,7 @@ from word_dataset_processor import TextProcessor
 
 
 def run_text_model():
-    """Train a 20-layer network on a tiny text dataset."""
+    """Train a 30-layer network on a tiny text dataset."""
     texts = [
         "Cats are wonderful pets",
         "Dogs are loyal animals",
@@ -15,8 +15,8 @@ def run_text_model():
     tp = TextProcessor()
     vectors = tp.fit_transform(texts)
     input_size = len(tp.vocab)
-    # input + 18 hidden + output = 20 layers total
-    layer_sizes = [input_size] + [8] * 18 + [1]
+    # input + 28 hidden + output = 30 layers total
+    layer_sizes = [input_size] + [8] * 28 + [1]
     net = DeepNeuralNetwork(layer_sizes)
     net.train(vectors, labels, epochs=200, lr=0.05)
     for t, v in zip(texts, vectors):

--- a/linear_regression.py
+++ b/linear_regression.py
@@ -1,0 +1,28 @@
+import random
+
+class LinearRegression:
+    def __init__(self):
+        self.w = random.uniform(-1, 1)
+        self.b = random.uniform(-1, 1)
+
+    def predict(self, x):
+        return self.w * x + self.b
+
+    def train(self, X, y, epochs=1000, lr=0.01):
+        for _ in range(epochs):
+            for xi, yi in zip(X, y):
+                pred = self.predict(xi)
+                error = pred - yi
+                self.w -= lr * error * xi
+                self.b -= lr * error
+
+if __name__ == "__main__":
+    X = list(range(10))
+    y = [2 * x + 1 for x in X]
+
+    model = LinearRegression()
+    model.train(X, y, epochs=2000, lr=0.01)
+
+    for xi in X:
+        pred = model.predict(xi)
+        print(f"x={xi} => y_pred={pred:.2f}")

--- a/logistic_regression.py
+++ b/logistic_regression.py
@@ -1,0 +1,51 @@
+import random
+import math
+
+class LogisticRegression:
+    def __init__(self, n_features):
+        # Initialize weights and bias randomly
+        self.weights = [random.uniform(-0.5, 0.5) for _ in range(n_features)]
+        self.bias = random.uniform(-0.5, 0.5)
+
+    def _sigmoid(self, z):
+        # Sigmoid activation function
+        return 1 / (1 + math.exp(-z))
+
+    def predict_proba(self, x):
+        # Calculate probability for a single sample
+        z = sum(w * x_i for w, x_i in zip(self.weights, x)) + self.bias
+        return self._sigmoid(z)
+
+    def predict(self, x):
+        # Convert probability to class label
+        return 1 if self.predict_proba(x) >= 0.5 else 0
+
+    def train(self, X, y, epochs=1000, lr=0.1):
+        # Basic gradient descent training loop
+        for _ in range(epochs):
+            for features, label in zip(X, y):
+                prediction = self.predict_proba(features)
+                error = prediction - label
+                # Update weights and bias
+                for j in range(len(self.weights)):
+                    self.weights[j] -= lr * error * features[j]
+                self.bias -= lr * error
+
+if __name__ == "__main__":
+    # Simple OR gate dataset
+    X = [
+        [0, 0],
+        [0, 1],
+        [1, 0],
+        [1, 1],
+    ]
+    y = [0, 1, 1, 1]
+
+    model = LogisticRegression(n_features=2)
+    model.train(X, y, epochs=5000, lr=0.1)
+
+    for features in X:
+        prob = model.predict_proba(features)
+        pred = model.predict(features)
+        print(f"Input: {features} => Prob: {prob:.3f}, Predicted: {pred}")
+

--- a/naive_bayes.py
+++ b/naive_bayes.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+
+class NaiveBayes:
+    def __init__(self):
+        self.class_counts = defaultdict(int)
+        self.feature_counts = defaultdict(lambda: defaultdict(int))
+        self.vocab = set()
+
+    def train(self, X, y):
+        for text, label in zip(X, y):
+            self.class_counts[label] += 1
+            for word in text.split():
+                self.vocab.add(word)
+                self.feature_counts[label][word] += 1
+
+    def predict(self, text):
+        scores = {}
+        total_docs = sum(self.class_counts.values())
+        for label in self.class_counts:
+            prior = self.class_counts[label] / total_docs
+            score = prior
+            for word in text.split():
+                word_freq = self.feature_counts[label][word] + 1
+                denom = sum(self.feature_counts[label].values()) + len(self.vocab)
+                score *= word_freq / denom
+            scores[label] = score
+        return max(scores, key=scores.get)
+
+if __name__ == "__main__":
+    X = ["spam offer secret", "secret click secret", "sport play win", "play sports today"]
+    y = ["spam", "spam", "ham", "ham"]
+
+    nb = NaiveBayes()
+    nb.train(X, y)
+    test = "secret offer today"
+    pred = nb.predict(test)
+    print(f"Text: '{test}' => Predicted class: {pred}")

--- a/pca.py
+++ b/pca.py
@@ -1,0 +1,39 @@
+import math
+
+class PCA:
+    def __init__(self, n_components):
+        self.n_components = n_components
+        self.components = []
+        self.mean = []
+
+    def fit(self, X):
+        n_samples = len(X)
+        n_features = len(X[0])
+        self.mean = [sum(col)/n_samples for col in zip(*X)]
+        centered = [[x_j - self.mean[j] for j, x_j in enumerate(x)] for x in X]
+        cov = [[0.0]*n_features for _ in range(n_features)]
+        for x in centered:
+            for i in range(n_features):
+                for j in range(n_features):
+                    cov[i][j] += x[i]*x[j]
+        for i in range(n_features):
+            for j in range(n_features):
+                cov[i][j] /= n_samples-1
+        # naive power iteration for first component
+        comp = [1.0]*n_features
+        for _ in range(100):
+            new = [sum(cov[i][j]*comp[j] for j in range(n_features)) for i in range(n_features)]
+            norm = math.sqrt(sum(v*v for v in new))
+            comp = [v/norm for v in new]
+        self.components = [comp[:self.n_components]]
+
+    def transform(self, X):
+        centered = [[x_j - self.mean[j] for j, x_j in enumerate(x)] for x in X]
+        return [[sum(a*b for a,b in zip(comp,row)) for comp in self.components] for row in centered]
+
+if __name__ == "__main__":
+    X = [[2,0],[0,2],[3,1],[1,3]]
+    pca = PCA(n_components=1)
+    pca.fit(X)
+    reduced = pca.transform(X)
+    print("Reduced vectors:", reduced)

--- a/perceptron.py
+++ b/perceptron.py
@@ -1,0 +1,36 @@
+import random
+
+class Perceptron:
+    def __init__(self, n_inputs):
+        self.weights = [random.uniform(-0.5, 0.5) for _ in range(n_inputs)]
+        self.bias = random.uniform(-0.5, 0.5)
+
+    def predict(self, x):
+        activation = sum(w * x_i for w, x_i in zip(self.weights, x)) + self.bias
+        return 1 if activation >= 0 else 0
+
+    def train(self, X, y, epochs=20, lr=0.1):
+        for _ in range(epochs):
+            for features, label in zip(X, y):
+                pred = self.predict(features)
+                error = label - pred
+                for i in range(len(self.weights)):
+                    self.weights[i] += lr * error * features[i]
+                self.bias += lr * error
+
+if __name__ == "__main__":
+    # AND gate
+    X = [
+        [0, 0],
+        [0, 1],
+        [1, 0],
+        [1, 1],
+    ]
+    y = [0, 0, 0, 1]
+
+    p = Perceptron(2)
+    p.train(X, y, epochs=10, lr=0.1)
+
+    for features in X:
+        pred = p.predict(features)
+        print(f"Input: {features} => Predicted: {pred}")

--- a/q_learning.py
+++ b/q_learning.py
@@ -1,0 +1,47 @@
+import random
+
+class GridWorld:
+    def __init__(self, n_states=5):
+        self.n_states = n_states
+        self.end = n_states - 1
+
+    def step(self, state, action):
+        if action == 1:
+            next_state = min(self.end, state + 1)
+        else:
+            next_state = max(0, state - 1)
+        reward = 1 if next_state == self.end else 0
+        return next_state, reward
+
+class QLearningAgent:
+    def __init__(self, n_states, n_actions=2):
+        self.q = [[0.0 for _ in range(n_actions)] for _ in range(n_states)]
+        self.n_actions = n_actions
+
+    def choose_action(self, state, eps=0.1):
+        if random.random() < eps:
+            return random.randint(0, self.n_actions - 1)
+        return max(range(self.n_actions), key=lambda a: self.q[state][a])
+
+    def learn(self, env, episodes=100, alpha=0.1, gamma=0.9):
+        for _ in range(episodes):
+            state = 0
+            while state != env.end:
+                action = self.choose_action(state)
+                next_state, reward = env.step(state, action)
+                best_next = max(self.q[next_state])
+                self.q[state][action] += alpha * (reward + gamma * best_next - self.q[state][action])
+                state = next_state
+
+if __name__ == "__main__":
+    env = GridWorld(n_states=5)
+    agent = QLearningAgent(n_states=5)
+    agent.learn(env, episodes=200)
+
+    state = 0
+    steps = 0
+    while state != env.end and steps < 10:
+        action = agent.choose_action(state, eps=0)
+        state, _ = env.step(state, action)
+        print(f"State: {state}")
+        steps += 1

--- a/rnn.py
+++ b/rnn.py
@@ -1,0 +1,66 @@
+import random
+import math
+
+class SimpleRNN:
+    def __init__(self, input_size, hidden_size):
+        self.w_xh = [[random.uniform(-0.5,0.5) for _ in range(input_size)] for _ in range(hidden_size)]
+        self.w_hh = [[random.uniform(-0.5,0.5) for _ in range(hidden_size)] for _ in range(hidden_size)]
+        self.w_hy = [random.uniform(-0.5,0.5) for _ in range(hidden_size)]
+        self.b_h = [0.0]*hidden_size
+        self.b_y = 0.0
+
+    def _sigmoid(self, z):
+        return 1/(1+math.exp(-z))
+
+    def _forward(self, seq):
+        h = [0.0]*len(self.w_xh)
+        for x in seq:
+            new_h = []
+            for j in range(len(self.w_xh)):
+                z = sum(w*x_i for w,x_i in zip(self.w_xh[j],[x])) + sum(w*h_i for w,h_i in zip(self.w_hh[j],h)) + self.b_h[j]
+                new_h.append(math.tanh(z))
+            h = new_h
+        y = self._sigmoid(sum(w*h_i for w,h_i in zip(self.w_hy,h)) + self.b_y)
+        return h, y
+
+    def predict(self, seq):
+        _, y = self._forward(seq)
+        return 1 if y >= 0.5 else 0
+
+    def train(self, data, labels, epochs=500, lr=0.1):
+        for _ in range(epochs):
+            for seq, label in zip(data, labels):
+                h_states = [[0.0]*len(self.w_xh)]
+                h = [0.0]*len(self.w_xh)
+                for x in seq:
+                    new_h = []
+                    for j in range(len(self.w_xh)):
+                        z = sum(w*x_i for w,x_i in zip(self.w_xh[j],[x])) + sum(w*h_i for w,h_i in zip(self.w_hh[j],h)) + self.b_h[j]
+                        new_h.append(math.tanh(z))
+                    h = new_h
+                    h_states.append(h)
+                y = self._sigmoid(sum(w*h_i for w,h_i in zip(self.w_hy,h)) + self.b_y)
+                dy = y - label
+                # output gradients
+                for j in range(len(self.w_hy)):
+                    self.w_hy[j] -= lr * dy * h[j]
+                self.b_y -= lr * dy
+                # hidden gradients (backprop through time up to seq len)
+                dh_next = [0.0]*len(self.w_xh)
+                for t in reversed(range(len(seq))):
+                    dh = [dh_next[j] + dy*self.w_hy[j]*(1-h_states[t+1][j]**2) for j in range(len(self.w_xh))]
+                    for j in range(len(self.w_xh)):
+                        self.b_h[j] -= lr * dh[j]
+                        self.w_xh[j][0] -= lr * dh[j]*seq[t]
+                        for k in range(len(self.w_xh)):
+                            self.w_hh[j][k] -= lr * dh[j]*h_states[t][k]
+                    dh_next = [sum(self.w_hh[k][j]*dh[k] for k in range(len(self.w_xh))) for j in range(len(self.w_xh))]
+
+if __name__ == "__main__":
+    data = [[0,1,0],[1,0,1],[1,1,1],[0,0,0]]
+    labels = [1,1,0,0]  # parity of ones mod 2
+    rnn = SimpleRNN(input_size=1, hidden_size=2)
+    rnn.train(data, labels, epochs=200)
+    for seq in data:
+        pred = rnn.predict(seq)
+        print(f"Seq: {seq} => Predicted: {pred}")

--- a/simple_nn.py
+++ b/simple_nn.py
@@ -1,0 +1,89 @@
+import random
+import math
+
+class SimpleNeuralNetwork:
+    def __init__(self, n_inputs, n_hidden):
+        # weights from input layer to hidden layer
+        self.w1 = [[random.uniform(-0.5, 0.5) for _ in range(n_inputs)] for _ in range(n_hidden)]
+        self.b1 = [random.uniform(-0.5, 0.5) for _ in range(n_hidden)]
+        # weights from hidden layer to single output neuron
+        self.w2 = [random.uniform(-0.5, 0.5) for _ in range(n_hidden)]
+        self.b2 = random.uniform(-0.5, 0.5)
+
+    def _sigmoid(self, z):
+        return 1 / (1 + math.exp(-z))
+
+    def _sigmoid_deriv(self, a):
+        return a * (1 - a)
+
+    def predict_proba(self, x):
+        # forward pass
+        hidden = []
+        for weights, bias in zip(self.w1, self.b1):
+            z = sum(w * x_i for w, x_i in zip(weights, x)) + bias
+            hidden.append(self._sigmoid(z))
+        z2 = sum(w * h for w, h in zip(self.w2, hidden)) + self.b2
+        return self._sigmoid(z2)
+
+    def predict(self, x):
+        return 1 if self.predict_proba(x) >= 0.5 else 0
+
+    def train(self, X, y, epochs=10000, lr=0.1):
+        for _ in range(epochs):
+            for features, label in zip(X, y):
+                # forward
+                hidden = []
+                hidden_z = []
+                for weights, bias in zip(self.w1, self.b1):
+                    z = sum(w * x_i for w, x_i in zip(weights, features)) + bias
+                    hidden_z.append(z)
+                    hidden.append(self._sigmoid(z))
+                output_z = sum(w*h for w, h in zip(self.w2, hidden)) + self.b2
+                output = self._sigmoid(output_z)
+
+                # output error (cross-entropy derivative)
+                delta_out = output - label
+
+                # hidden layer errors
+                deltas_hidden = []
+                for j in range(len(self.w1)):
+                    delta = self.w2[j] * delta_out * self._sigmoid_deriv(hidden[j])
+                    deltas_hidden.append(delta)
+
+                # update weights hidden->output
+                for j in range(len(self.w2)):
+                    self.w2[j] -= lr * delta_out * hidden[j]
+                self.b2 -= lr * delta_out
+
+                # update weights input->hidden
+                for j in range(len(self.w1)):
+                    for i in range(len(self.w1[j])):
+                        self.w1[j][i] -= lr * deltas_hidden[j] * features[i]
+                    self.b1[j] -= lr * deltas_hidden[j]
+
+    def evaluate(self, X, y):
+        correct = 0
+        for features, label in zip(X, y):
+            if self.predict(features) == label:
+                correct += 1
+        return correct / len(X)
+
+if __name__ == "__main__":
+    # XOR dataset
+    X = [
+        [0, 0],
+        [0, 1],
+        [1, 0],
+        [1, 1],
+    ]
+    y = [0, 1, 1, 0]
+
+    nn = SimpleNeuralNetwork(n_inputs=2, n_hidden=2)
+    nn.train(X, y, epochs=20000, lr=0.1)
+
+    acc = nn.evaluate(X, y)
+    print(f"Training accuracy: {acc*100:.2f}%")
+    for features in X:
+        prob = nn.predict_proba(features)
+        pred = nn.predict(features)
+        print(f"Input: {features} => Prob: {prob:.3f}, Predicted: {pred}")

--- a/word_dataset_processor.py
+++ b/word_dataset_processor.py
@@ -1,0 +1,156 @@
+import math
+import csv
+import json
+import re
+import xml.etree.ElementTree as ET
+from typing import List
+
+class TextProcessor:
+    """Text processor with loaders and basic NLP utilities.
+
+    The processor can read datasets from six file formats and provides
+    several text analysis helpers including stopword removal, stemming,
+    n-gram generation and TF-IDF computation.
+    """
+
+    def __init__(self):
+        self.vocab: List[str] = []
+        self.word_to_idx = {}
+        self.idf = {}
+        self.stopwords = {
+            'the', 'a', 'and', 'or', 'to', 'of', 'in', 'on', 'is', 'are',
+            'for', 'with', 'an', 'as'
+        }
+
+    def _tokenize(self, text: str) -> List[str]:
+        """Lowercase and split text into alphabetic tokens."""
+        tokens = []
+        word = ''
+        for ch in text.lower():
+            if ch.isalpha():
+                word += ch
+            else:
+                if word:
+                    tokens.append(word)
+                    word = ''
+        if word:
+            tokens.append(word)
+        return tokens
+
+    # ------------------------------------------------------------------
+    # Processing helpers (6 systems)
+
+    def remove_stopwords(self, tokens: List[str]) -> List[str]:
+        """Return tokens not in the stopword set."""
+        return [t for t in tokens if t not in self.stopwords]
+
+    def stem_tokens(self, tokens: List[str]) -> List[str]:
+        """Very small stemmer removing common suffixes."""
+        stems = []
+        for t in tokens:
+            for suf in ('ing', 'ed', 's'):
+                if t.endswith(suf) and len(t) > len(suf) + 2:
+                    t = t[:-len(suf)]
+                    break
+            stems.append(t)
+        return stems
+
+    def bigrams(self, tokens: List[str]) -> List[str]:
+        return ['{}_{}'.format(tokens[i], tokens[i+1])
+                for i in range(len(tokens)-1)]
+
+    def trigrams(self, tokens: List[str]) -> List[str]:
+        return ['{}_{}_{}'.format(tokens[i], tokens[i+1], tokens[i+2])
+                for i in range(len(tokens)-2)]
+
+    def term_frequency(self, tokens: List[str]):
+        counts = {}
+        for tok in tokens:
+            counts[tok] = counts.get(tok, 0) + 1
+        return counts
+
+    # ------------------------------------------------------------------
+    # Dataset loaders supporting six file types (6 systems)
+
+    def load_txt(self, path: str) -> List[str]:
+        with open(path, 'r', encoding='utf-8') as fh:
+            return [line.strip() for line in fh if line.strip()]
+
+    def load_csv(self, path: str, text_column: int = 0) -> List[str]:
+        rows = []
+        with open(path, newline='', encoding='utf-8') as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                if len(row) > text_column:
+                    rows.append(row[text_column])
+        return rows
+
+    def load_json(self, path: str, key: str = 'text') -> List[str]:
+        with open(path, 'r', encoding='utf-8') as fh:
+            data = json.load(fh)
+        return [item[key] for item in data if key in item]
+
+    def load_xml(self, path: str, tag: str = 'text') -> List[str]:
+        tree = ET.parse(path)
+        root = tree.getroot()
+        return [elem.text or '' for elem in root.iter(tag)]
+
+    def load_html(self, path: str) -> List[str]:
+        with open(path, 'r', encoding='utf-8') as fh:
+            text = fh.read()
+        text = re.sub('<[^<]+?>', ' ', text)
+        return [text.strip()]
+
+    def load_markdown(self, path: str) -> List[str]:
+        with open(path, 'r', encoding='utf-8') as fh:
+            text = fh.read()
+        text = re.sub(r'[#*>`]', ' ', text)
+        return [text.strip()]
+
+    def fit(self, texts: List[str]):
+        doc_counts = {}
+        for text in texts:
+            tokens = self._tokenize(text)
+            unique = set(tokens)
+            for token in unique:
+                doc_counts[token] = doc_counts.get(token, 0) + 1
+        self.vocab = sorted(doc_counts.keys())
+        self.word_to_idx = {w: i for i, w in enumerate(self.vocab)}
+        n_docs = len(texts)
+        self.idf = {w: math.log(n_docs / (1 + doc_counts[w])) for w in self.vocab}
+
+    def transform(self, texts: List[str]) -> List[List[float]]:
+        vectors = []
+        for text in texts:
+            tokens = self._tokenize(text)
+            total = len(tokens)
+            counts = {}
+            for tok in tokens:
+                if tok in self.word_to_idx:
+                    counts[tok] = counts.get(tok, 0) + 1
+            vec = [0.0 for _ in self.vocab]
+            for tok, count in counts.items():
+                idx = self.word_to_idx[tok]
+                tf = count / total if total else 0
+                vec[idx] = tf * self.idf[tok]
+            vectors.append(vec)
+        return vectors
+
+    def fit_transform(self, texts: List[str]) -> List[List[float]]:
+        self.fit(texts)
+        return self.transform(texts)
+
+if __name__ == '__main__':
+    dataset = [
+        "The quick brown fox jumps over the lazy dog",
+        "Never jump over the lazy dog quickly",
+        "Foxes are quick and dogs are lazy",
+        "Dog owners love quick pets",
+    ]
+    processor = TextProcessor()
+    vectors = processor.fit_transform(dataset)
+    print("Vocabulary:", processor.vocab)
+    print("IDF:", [f"{w}:{processor.idf[w]:.2f}" for w in processor.vocab])
+    for text, vec in zip(dataset, vectors):
+        print(text)
+        print([f"{v:.2f}" for v in vec])

--- a/word_dataset_processor.py
+++ b/word_dataset_processor.py
@@ -3,6 +3,7 @@ import csv
 import json
 import re
 import xml.etree.ElementTree as ET
+import os
 from typing import List
 
 class TextProcessor:
@@ -106,6 +107,34 @@ class TextProcessor:
             text = fh.read()
         text = re.sub(r'[#*>`]', ' ', text)
         return [text.strip()]
+
+    def load_path(self, path: str) -> List[str]:
+        """Load all supported files from a single file or directory."""
+        paths = []
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for name in files:
+                    ext = os.path.splitext(name)[1].lower()
+                    if ext in {'.txt', '.csv', '.json', '.xml', '.html', '.md'}:
+                        paths.append(os.path.join(root, name))
+        else:
+            paths.append(path)
+        texts = []
+        for p in paths:
+            ext = os.path.splitext(p)[1].lower()
+            if ext == '.txt':
+                texts.extend(self.load_txt(p))
+            elif ext == '.csv':
+                texts.extend(self.load_csv(p))
+            elif ext == '.json':
+                texts.extend(self.load_json(p))
+            elif ext == '.xml':
+                texts.extend(self.load_xml(p))
+            elif ext == '.html':
+                texts.extend(self.load_html(p))
+            elif ext == '.md':
+                texts.extend(self.load_markdown(p))
+        return texts
 
     def fit(self, texts: List[str]):
         doc_counts = {}


### PR DESCRIPTION
## Summary
- enhance text processor with stopword removal, stemming, n-grams and term frequency helpers
- add loaders for text, CSV, JSON, XML, HTML and Markdown files
- document dataset processor capabilities and example in README
- add central `ai_model.py` script that imports all algorithms and auto-runs a demo for a chosen task

## Testing
- `python3 logistic_regression.py | head -n 5`
- `python3 simple_nn.py | head -n 5`
- `python3 complex_nn.py | head -n 5`
- `python3 perceptron.py | head -n 5`
- `python3 word_dataset_processor.py | head -n 10`
- `python3 ai_model.py classification | head -n 5`
- `python3 ai_model.py regression | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6868be91b17483309d23b7ee9e5f0eed